### PR TITLE
Fix: failed jobs can call done() twice

### DIFF
--- a/src/Queue.js
+++ b/src/Queue.js
@@ -81,7 +81,7 @@ export class Queue {
 					const job = new jobClass(kueJob.data, kueJob)
 					result = job.$handle(this.app, this)
 				} catch(err) {
-					return done(this.handleError(err, done))
+					return this.handleError(err, done)
 				}
 
 				if(result.isNil || typeof result.then !== 'function') {


### PR DESCRIPTION
Some failed jobs are calling done() twice instead of once, with the second call being passed into the first as an argument. This can result in a Kue error with failed jobs getting stuck as active. The issue is resolved by removing the first done() call.