### PR TITLE
add Job.$isDelayedFor() function

### DIFF
--- a/src/Job.js
+++ b/src/Job.js
@@ -43,6 +43,10 @@ export class Job {
 		return this
 	}
 
+	$isDelayedFor(ms) {
+		return (this.$kueJob.promote_at - Date.now()) > ms
+	}
+
 	$attempts(...args) {
 		this.$kueJob.attempts(...args)
 		return this


### PR DESCRIPTION
New Feature: `Job.$isDelayedFor(ms)`

Use: Check whether a job is `delayed` for some minimum length of time.

Inputs: Accepts an integer of milliseconds and returns a boolean

Use case: When working with delayed jobs it can be useful to check how much longer a job will be delayed for when thinking of performing an operation on it, such as adding data to it. It wouldn't do for the job to be processed in the middle of editing it so first check that it still has a minimum amount of delay left to go (i.e. long enough to perform the desired updates). h/t @shnhrrsn 

```javascript
if(job.$isDelayedFor(50)) {
   //add data to job
   job.$save()
} else {
   //create a new job with the data
}
```