### PR TITLE
SQS Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "beanstalk",
     "ampq",
     "queue",
-    "faktory"
+    "faktory",
+    "sqs"
   ],
   "peerDependencies": {
     "grind-cli": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "amqplib": "^0.5.1",
     "ava": "^0.18.1",
+    "aws-sdk": "^2.172.0",
     "babel-cli": ">=6.7 <=7.0",
     "babel-eslint": "^6.1.1",
     "babel-preset-grind": "^0.8.0-beta.1",

--- a/src/Commands/QueueWorkCommand.js
+++ b/src/Commands/QueueWorkCommand.js
@@ -11,7 +11,7 @@ export class QueueWorkCommand extends Command {
 
 	options = [
 		new InputOption('queue', InputOption.VALUE_OPTIONAL, 'Specify the queue(s) to perform work for.'),
-		new InputOption('concurrency', InputOption.VALUE_OPTIONAL, 'Number of jobs to process concurrency.', '1'),
+		new InputOption('concurrency', InputOption.VALUE_OPTIONAL, 'Number of jobs to process concurrently.', '1'),
 		new InputOption('watch', InputOption.VALUE_OPTIONAL, 'Folders to watch for changes')
 	]
 
@@ -36,7 +36,7 @@ export class QueueWorkCommand extends Command {
 
 	async run() {
 		let queues = null
-		const connection = this.app.queue.get(this.argument('connection'))
+		const connection = await this.app.queue.get(this.argument('connection'))
 
 		if(this.containsOption('queue')) {
 			queues = this.option('queue').split(/,/).map(job => job.trim()).filter(job => job.length > 0)

--- a/src/Drivers/BaseDriver.js
+++ b/src/Drivers/BaseDriver.js
@@ -2,6 +2,7 @@
  * Base class all drivers must extend
  */
 export class BaseDriver {
+
 	app = null
 	state = null
 	retryDelay = 90000
@@ -14,6 +15,15 @@ export class BaseDriver {
 		if(config.retry_delay) {
 			this.retryDelay = Number.parseInt(config.retry_delay)
 		}
+	}
+
+	/**
+	* Performs setup operations when starting the driver
+	*
+	* @return Promise
+	*/
+	ready() {
+		return Promise.resolve()
 	}
 
 	/**

--- a/src/Drivers/SQSDriver.js
+++ b/src/Drivers/SQSDriver.js
@@ -1,0 +1,105 @@
+import './BaseDriver'
+import '../Support/SQS'
+
+/**
+ * AWS Simple Queue Service (SQS) backed Queue Driver
+ */
+export class SQSDriver extends BaseDriver {
+	client = null
+
+	constructor(app, config) {
+		super(app, config)
+
+		this.client = new SQS(config)
+	}
+
+	ready() {
+		return this.client.createQueue()
+	}
+
+	connect() {
+		return Promise.resolve()
+	}
+
+	async dispatch(job) {
+		const payload = this.buildPayload(job)
+		const queueUrl = this.client.queueUrls[payload.queue]
+
+		if(queueUrl.isNil) {
+			return Promise.reject(`Unable to find SQS url for job queue ${payload.queue}`)
+		}
+
+		const params = {
+			QueueUrl: queueUrl,
+			MessageBody: JSON.stringify(payload),
+			DelaySeconds: payload.delay || 0
+		}
+
+		return this.client.put(params)
+	}
+
+	listen(queues, concurrency, jobHandler, errorHandler) {
+		// SQS can batch ingest up to 10 jobs in a single call
+		const concurrentListens = Math.ceil(concurrency / 10)
+		const remainderJobConcurrency = 10 - ((concurrentListens * 10) - concurrency)
+
+		const listeners = [ ]
+
+		for(let i = 0; i < concurrentListens; i++) {
+			for(const queue of queues) {
+				let concurrentJobs = 10
+
+				if(i === (concurrentListens - 1)) {
+					concurrentJobs = remainderJobConcurrency
+				}
+
+				listeners.push(this._listen(queue, concurrentJobs, jobHandler, errorHandler))
+			}
+		}
+
+		return Promise.all(listeners)
+	}
+
+	_listen(queue, concurrency, jobHandler, errorHandler) {
+		return this.client.watch(queue, concurrency, async function callback(jobData, dispatchedAt, pastTries = 1) {
+			const job = JSON.parse(jobData)
+			const isExpired = timeout => {
+				return (timeout !== 0) && ((new Date - dispatchedAt) > timeout)
+			}
+
+			try {
+				if(isExpired(job.timeout)) {
+					return
+				}
+
+				await jobHandler(job)
+			} catch(err) {
+				try {
+					const tries = Number.parseInt(job.tries) || 1
+
+					if((pastTries >= tries) || isExpired(job.timeout)) {
+						throw err
+					}
+
+					if(job.retry_delay > 0) {
+						await new Promise(resolve => {
+							return setTimeout(() => {
+								return resolve()
+							}, job.retry_delay)
+						})
+					}
+				} catch(err) {
+					return errorHandler(job, err)
+				}
+
+				return callback(jobData, dispatchedAt, pastTries += 1)
+			}
+		})
+	}
+
+	destroy() {
+		this.client.constructor.queueUrls = { }
+		return super.destroy()
+	}
+
+}

--- a/src/Drivers/SQSDriver.js
+++ b/src/Drivers/SQSDriver.js
@@ -31,8 +31,11 @@ export class SQSDriver extends BaseDriver {
 
 		const params = {
 			QueueUrl: queueUrl,
-			MessageBody: JSON.stringify(payload),
-			DelaySeconds: payload.delay || 0
+			MessageBody: JSON.stringify(payload)
+		}
+
+		if(payload.delay > 0) {
+			params.DelaySeconds = Math.round(payload.delay / 1000)
 		}
 
 		return this.client.put(params)
@@ -98,6 +101,7 @@ export class SQSDriver extends BaseDriver {
 	}
 
 	destroy() {
+		this.client.isShutdown = true
 		this.client.constructor.queueUrls = { }
 		return super.destroy()
 	}

--- a/src/QueueProvider.js
+++ b/src/QueueProvider.js
@@ -3,9 +3,14 @@ import './QueueFactory'
 import './Commands/MakeJobCommand'
 import './Commands/QueueWorkCommand'
 
-export function QueueProvider(app, classes = { }) {
+export async function QueueProvider(app, classes = { }) {
 	const factoryClass = classes.factoryClass || QueueFactory
 	app.queue = new factoryClass(app)
+
+	for(const connectionName of Object.keys(app.config.get('queue.connections'))) {
+		// Trigger initial setup of backend engines
+		await app.queue.get(connectionName)
+	}
 
 	if(app.cli.isNil) {
 		return

--- a/src/Support/SQS.js
+++ b/src/Support/SQS.js
@@ -1,0 +1,244 @@
+import { MissingPackageError } from 'grind-framework'
+
+let sqs = null
+
+/**
+ * Loads the aws-sdk package or throws an error
+ * if it hasn‘t been added
+ */
+function loadPackage() {
+	if(!sqs.isNil) {
+		return
+	}
+
+	try {
+		sqs = require('aws-sdk').SQS
+	} catch(err) {
+		throw new MissingPackageError('aws-sdk')
+	}
+}
+
+/**
+ * Wrapper around AWS SQS to provide a
+ * promise based interface + simplifies a few ops
+ */
+export class SQS {
+
+	static queueUrls = { }
+
+	get queueUrls() {
+		return this.constructor.queueUrls
+	}
+
+	client = null
+	queueConfigs = null
+
+	constructor(config) {
+		loadPackage()
+		this.queueConfigs = config.queues
+
+		const serviceConfig = {
+			region: config.region || 'us-east-1'
+		}
+
+		// NOTE preferred way to access SQS is via an AWS IAM role
+		if(!config.access_key.isNil && !config.secret_key.isNil) {
+			serviceConfig.accessKeyId = config.access_key
+			serviceConfig.secretAccessKey = config.secret_key
+		}
+
+		this.client = new sqs(serviceConfig)
+	}
+
+  /*
+		To create queues, use the `queues` object via the config:
+		"connections": {
+			"sqs-connection": {
+				"driver": "sqs",
+				"queues": {
+					"test-queue-name": { ...queue options here },
+					"test-queue-name2": { "QueueUrl": "https://sqs.us-east-1..." }
+				}
+			}
+		}
+
+		On app start, grind-queue calls AWS to create/update your queues as necessary and grab the URLs.
+		For any queue options not specified, we'll use the AWS defaults.
+		The queue name `default` is reserved for setting queue defaults different from AWS's.
+
+		If you want to use an SQS queue managed without grind-queue, set the QueueUrl option.
+		Grind-queue will use that url and, on startup, will skip the inital calls to AWS.
+	*/
+	async createQueue() {
+		for(const [ name, queueAttributes ] of Object.entries(this.queueConfigs)) {
+			// `default` queue name is reserved for setting new defaults
+			if(name === 'default') {
+				continue
+			}
+
+			// If QueueUrl option is set, simply use the url
+			if(!queueAttributes.QueueUrl.isNil) {
+				this.queueUrls[name] = queueAttributes.QueueUrl
+				continue
+			}
+
+			const defaultAttributes = Object.assign({
+				// AWS defaults - set explicitly here to ovveride changes made via SQS console/cli
+				DelaySeconds: '0',
+				MaximumMessageSize: '262144',
+				MessageRetentionPeriod: '345600',
+				ReceiveMessageWaitTimeSeconds: '0',
+				VisibilityTimeout: '30'
+			}, (this.queueConfigs.default || { }))
+
+			const params = {
+				QueueName: name,
+				Attributes: {
+					...Object.assign(defaultAttributes, queueAttributes)
+				}
+			}
+
+			await new Promise((res, rej) => this.findOrCreateQueue(res, rej, name, params))
+		}
+	}
+
+	async findOrCreateQueue(resolve, reject, name, params) {
+		let queueUrl = params.QueueUrl
+
+		if(!queueUrl.isNil) {
+			// set remote url for queue
+			this.queueUrls[name] = queueUrl
+			return resolve()
+		}
+
+		try {
+			queueUrl = await new Promise((resolve2, reject2) => {
+				return this.client.createQueue(params, async (err, data) => {
+					if(!err.isNil && (err.code === 'QueueAlreadyExists')) {
+						// error triggered when remote queue exists but config and remote attributes differ
+						await this.findAndUpdateQueue(params)
+						return resolve2(params.QueueUrl)
+					} else if(!err.isNil) {
+						return reject2(err)
+					}
+
+					// resolves here if queue is created -or- queue exists and config and remote attributes match
+					return resolve2(data.QueueUrl)
+				})
+			})
+		} catch(err) {
+			return reject(err)
+		}
+
+		// set remote url for queue
+		this.queueUrls[name] = queueUrl
+		return resolve()
+	}
+
+	async findAndUpdateQueue(params) {
+		// Set queue url then update queue attributes
+		params.QueueUrl = await new Promise((resolve, reject) => {
+			return this.client.getQueueUrl({ QueueName: params.QueueName }, (err, data) => {
+				return err.isNil ? resolve(data.QueueUrl) : reject(err)
+			})
+		})
+
+		return new Promise((resolve, reject) => {
+			delete params.QueueName
+
+			return this.client.setQueueAttributes(params, err /* ,data */ => {
+				return err.isNil ? resolve() : reject(err)
+			})
+		})
+	}
+
+	put(params) {
+		return new Promise((resolve, reject) => {
+			return this.client.sendMessage(params, (err, data) => {
+				return err.isNil ? resolve(data) : reject(err)
+			})
+		})
+	}
+
+	async watch(queue, concurrency, handler) {
+		const queueUrl = this.queueUrls[queue]
+
+		if(queueUrl.isNil) {
+			throw new Error(`Queue url not found ${queue}`)
+		}
+
+		const params = {
+			QueueUrl: queueUrl,
+			MaxNumberOfMessages: concurrency,
+			// VisibilityTimeout: 30  - set via queue-wide VisibilityTimeout
+			WaitTimeSeconds: 20,
+			AttributeNames: [ 'SentTimestamp' ]
+		}
+
+		const messages = await new Promise(resolve => {
+			return this.client.receiveMessage(params, (err, data) => {
+				if(err) {
+					return resolve()
+				} else if((data.Messages === void 0) || (data.Messages.length === 0)) {
+					return resolve()
+				}
+
+				return resolve(data.Messages)
+			})
+		})
+
+		if(Array.isArray(messages)) {
+			// Delete jobs from SQS so they are not reprocessed, then process them
+			await this.deleteFromQueue(queueUrl, messages)
+			await Promise.all(messages.filter(message => message.isDeleted).map(message => {
+				const messageData = message.Body
+				const dispatchedAt = new Date(message.Attributes.SentTimestamp)
+
+				return handler(messageData, dispatchedAt)
+			}))
+		}
+
+		// Once finished processing current jobs, re-watch the queue
+		return this.watch(queue, concurrency, handler)
+	}
+
+	async deleteFromQueue(url, messages) {
+		const params = {
+			QueueUrl: url,
+			Entries: messages.map((message, i) => {
+				return {
+					Id: `${i}`,
+					ReceiptHandle: message.ReceiptHandle
+				}
+			})
+		}
+
+		try {
+			await new Promise((resolve, reject) => {
+				return this.client.deleteMessageBatch(params, (err, data) => {
+					if(!err.isNil) {
+						return reject(err)
+					}
+
+					for(const result of data.Successful) {
+						messages[result.Id].isDeleted = true
+					}
+
+					if(data.Failed.length > 0) {
+						const failed = data.Failed
+						const mssg = failed.map(result => `{senderFault: ${result.SenderFault}, code: ${result.Code}}`)
+
+						Log.error(
+							`Failed to delete ${failed.length} messasges. Releasing back into queue. Error ${mssg}`
+						)
+					}
+
+					return resolve()
+				})
+			})
+		} catch(err) {
+			Log.error(`Failed to delete messasges. Releasing back into queue. Error ${err}`)
+		}
+	}
+
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import './Drivers/BaseDriver'
 import './Drivers/BeanstalkDriver'
 import './Drivers/FaktoryDriver'
 import './Drivers/RabbitDriver'
+import './Drivers/SQSDriver'
 
 export {
 	Job,
@@ -23,6 +24,7 @@ export {
 	BeanstalkDriver,
 	FaktoryDriver,
 	RabbitDriver,
+	SQSDriver,
 
 	// Commands
 	QueueWorkCommand,

--- a/test/SQSDriver.js
+++ b/test/SQSDriver.js
@@ -1,0 +1,94 @@
+import { serial as test } from 'ava'
+
+import './helpers/TestJob'
+import './helpers/Listener'
+import './helpers/Service'
+
+import '../src/Drivers/SQSDriver'
+
+const service = new Service(test, 'sqs', {
+	image: 'vsouza/sqs-local',
+	port: 9324
+})
+const queueName = 'test'
+
+test.beforeEach(async t => {
+	t.context.driver = new SQSDriver(null, {
+		endpoint: `http://localhost:${service.port}`,
+		access_key: 'fake-id',
+		secret_key: 'fake-secret',
+		queues: {
+			[queueName]: { }
+		}
+	})
+
+	await t.context.driver.ready()
+	return t.context.driver.connect()
+})
+
+test.afterEach.always(async t => {
+	const queueUrl = t.context.driver.client.queueUrls[queueName]
+	t.context.driver.destroy()
+
+	// Delete the queue so it will be recreated
+	// This prevents the current Listener's residual long-polling from getting the next test's messages
+	await new Promise((resolve, reject) => {
+		return t.context.driver.client.client.deleteQueue({ QueueUrl: queueUrl }, err => {
+			if(err) {
+				return reject(err)
+			}
+
+			return resolve()
+		})
+	})
+})
+
+test('dispatch', async t => {
+	const payload = { time: Date.now() }
+	const job = new TestJob({ ...payload })
+
+	await t.context.driver.dispatch(job)
+
+	return Listener(t.context.driver, job => t.deepEqual(job.data.data, payload))
+})
+
+test('retry dispatch', async t => {
+	const payload = { time: Date.now() }
+	const job = new TestJob({ ...payload })
+	let tries = 0
+
+	await t.context.driver.dispatch(job.$tries(2))
+
+	return Listener(t.context.driver, job => {
+		t.is(job.tries, 2)
+		t.deepEqual(job.data.data, payload)
+
+		if(++tries === 1 || tries > 2) {
+			throw new Error
+		}
+	})
+})
+
+test('multi dispatch', t => {
+	let count = 0
+
+	setTimeout(() => t.context.driver.dispatch(new TestJob({ id: 1 })), 50)
+	setTimeout(() => t.context.driver.dispatch(new TestJob({ id: 2 })), 100)
+	setTimeout(() => t.context.driver.dispatch(new TestJob({ id: 3 })), 200)
+	setTimeout(() => t.context.driver.dispatch(new TestJob({ id: 4 })), 400)
+
+	return Listener(t.context.driver, () => ++count < 4).then(() => t.is(count, 4))
+})
+
+test('delayed dispatch', async t => {
+	const payload = { time: Date.now() }
+	const job = new TestJob({ ...payload })
+
+	const dispatchedAt = Date.now()
+	await t.context.driver.dispatch(job.$delay(1000))
+
+	return Listener(t.context.driver, job => {
+		t.is(Date.now() - dispatchedAt >= 1000, true)
+		t.deepEqual(job.data.data, payload)
+	})
+})


### PR DESCRIPTION
## SQS

#### tldr:
- AWS SQS integration
- Create/update SQS queues via the config
- Supports the same outward facing api and error handling as the other integrations


#### Details:

##### Fetching Urls
SQS requires a queue url for most operations - it usually doens't accept just the name. The queue url can either be hardcoded into the app code or fetched via the sdk api. If the queue has not been created yet, however, then it needs to be created before the url can be fetched.

It's not a good idea to get this url for the first time when performing an in-app operation, such as the first time a job is dispatched. First, it requires time to fetch the url and even more time to create/update the queue if needed. Second, if multiple dispatches occur asynchronously, multiple unecessary api requests are sent to aws, which might also cause errors. 

The solution is to get the urls and/or create/update the queue on app-startup. The queue names and urls will be specified in the app config. 
For example: 
```json
		"connections": {
			"sqs-connection": {
				"driver": "sqs",
				"queues": {
					"test-queue-name": { ...queue options here },
					"test-queue-name2": { "QueueUrl": "https://sqs.us-east-1..." }
				}
			}
		}
        
```

It works as follows:
- On app start, grind-queue calls AWS to create/update your specified queues as necessary and grabs the URLs.
- For any queue options not specified in the config, we'll use the AWS defaults.
- The queue name `default` is reserved for setting queue defaults different from AWS's.

- If you want to use an SQS queue managed manually without grind-queue, set the QueueUrl option.
- Grind-queue will use that url and, on startup, will skip the inital calls to AWS.

This fetching required me to promisify some of the internal logic of getting queues in Queue.js, but that doesn't effect any functionality of the other services or impact outward usage.

##### Concurrency
SQS can batch recieve and delete messages up to 10 at a time. Concurrency takes advantage of this. If I set concurrency to 2, only one listener is used but a concurrency of 2 is set for it, so up to 2 jobs are received at a time. If I set concurrency to 13, then two listeners are used, one with a concurrency of 10 and the other with 3.

##### Deleting Jobs
When a job is received from an SQS queue, it is not automatically deleted. After a delay (default 30 seconds), the job becomes visible to the queue and will be delivered again, causing duplicate processing. Any delay in processing, therefore, can cause duplicates.

To avoid duplicates, jobs are deleted from SQS the moment they are received. Retries and retryDelays are handled on the app level by re-running the job handler with the original job data-payload.